### PR TITLE
Update README.md

### DIFF
--- a/commit&conquer/README.md
+++ b/commit&conquer/README.md
@@ -33,15 +33,15 @@ Una volta fatto il push, il developer svuota la riserva e guadagna punti:
 
 ## Bug
 
-Il developer ottiene un bug per ogni dado che ottiene lo stesso risultato di un altro dado:
+Il developer ottiene un bug per ogni coppia di dadi che ottiene lo stesso risultato di un altro dado:
 ```
 esempioBug = 5 dadi lanciati => 2, 3, 3, 5, 6 => ci sono 2 bug (3, 3)
 ```
 
 Il developer ignora il primo dado che ottiene il punteggio corrispondente al suo linguaggio
-senior, quando calcola i bug:
+senior, ie. Java (3), quando calcola i bug:
 ```
-esempioBugSenior_1 = 5 dadi lanciati => 3, 3, 3, 5, 6 => ci sono 2 bug (3, 3)
+esempioBugSenior_1 = 5 dadi lanciati => 3, 3, 3, 3, 6 => ci sono 2 bug (3, 3)
 
 esempioBugSenior_2 = 5 dadi lanciati => 2, 3, 3, 5, 6 => non ci sono bug
 ```


### PR DESCRIPTION
presupponendo che quanto abbia detto Edo sia vero ho corretto gli esempi

- reso esplicita la seniority del developer dell'esempio (Java)
- aggiunto un dado 3 al risultato in più per otterene 2 bug 
- resa esplicito che il bug è generato da ogni coppia di dadi

le istruzioni però si possono interpretare anche in altro modo, nello specifico la frase:

`Il developer ottiene un bug per ogni dado che ottiene lo stesso risultato di un altro dado`

si potrebbere riscrivere come:

`Il developer ottiene un bug per ogni **ulteriore** dado che ottiene lo stesso risultato di un altro dado`
